### PR TITLE
Add twitter and github widgets to landing

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -31,7 +31,6 @@ en:
 
 # landing cta
   cta:
-    title: Get started with Confidant today
     docs: View Docs
     github: Github
 

--- a/source/localizable/footer.html.erb
+++ b/source/localizable/footer.html.erb
@@ -9,12 +9,12 @@
       <article class="footer-contact">
         <ul class="footer-contact-list">
           <li class="footer-contact-list-item twitter-link">
-            <%= link_to t("built.twitter"), "//twitter.com/lyft" %>
+            <%= partial 'partials/twitter_widget' %>
           </li>
           <li class="footer-contact-list-item github-link">
-            <%= link_to t("built.github"), "//github.com/lyft/confidant" %>
+            <%= partial 'partials/github_widget' %>
           </li>
-          <li class="footer-contact-list-item github-link">
+          <li class="footer-contact-list-item">
             <%= link_to t("built.download"), "//www.lyft.com/app" %>
           </li>
         </ul>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -7,7 +7,6 @@ layout: layout
   <section class="body-content-container wrap-container" data-waypoint="hero-content">
     <h2 class="hero-headline"><%= t("index.headline") %></h2>
     <h3 class="hero-description"><%= t("index.description") %></h3>
-
     <div class="hero-banner-container">
       <div class="laptop">
       </div>
@@ -16,6 +15,7 @@ layout: layout
 </header>
 
 <div class="body-content-container wrap-container" role="main">
+  <%= partial 'partials/main_cta' %>
   <section class="introduction">
     <div class="introduction-container" data-waypoint="introduction-container">
       <div class="introduction-item second-graphic">
@@ -68,7 +68,6 @@ layout: layout
 
 <div class="landing-cta">
   <section class="wrap-container">
-    <h2 class="landing-cta-description"><%= t("cta.title") %></h2>
     <%= link_to t("cta.docs"),
       "#{locale_prefix}/basics/install/", class: "landing-cta-button-fill" %>
     <%= link_to t("cta.github"),

--- a/source/partials/_github_widget.erb
+++ b/source/partials/_github_widget.erb
@@ -1,0 +1,1 @@
+<iframe src="http://ghbtns.com/github-btn.html?user=lyft&repo=confidant&type=watch" height="30" width="70" frameborder="0" scrolling="0" style="width:70px; height: 30px;" class="github-btn" allowTransparency="true"></iframe>

--- a/source/partials/_global_nav.erb
+++ b/source/partials/_global_nav.erb
@@ -7,8 +7,10 @@
 
     <ul class="global-nav-list">
       <li class="global-nav-item">
-        <%= link_to t("navigation.github"),
-          "//github.com/lyft/confidant", class: "cta-link-nav" %>
+        <%= partial 'partials/twitter_widget' %>
+      </li>
+      <li class="global-nav-item">
+        <%= partial 'partials/github_widget' %>
       </li>
       <li class="global-nav-item">
         <%= link_to t("navigation.docs"),

--- a/source/partials/_main_cta.erb
+++ b/source/partials/_main_cta.erb
@@ -1,0 +1,8 @@
+<div class="landing-cta">
+  <section class="wrap-container">
+    <%= link_to t("cta.docs"),
+      "#{locale_prefix}/basics/install/", class: "landing-cta-button-fill" %>
+    <%= link_to t("cta.github"),
+      "//github.com/lyft/confidant", class: "landing-cta-button-outline" %>
+  </section>
+</div>

--- a/source/partials/_twitter_widget.erb
+++ b/source/partials/_twitter_widget.erb
@@ -1,0 +1,2 @@
+<a href="https://twitter.com/share" class="twitter-share-button" data-text="Confidant, your secret keeper" data-via="lyft" data-count="none">Tweet</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>

--- a/source/stylesheets/mixins/_button.scss
+++ b/source/stylesheets/mixins/_button.scss
@@ -3,6 +3,7 @@
   border-radius: $base-border-radius;
   display: inline-block;
   font-weight: $font-weight-bold;
+  margin: 0 0.5em;
   padding: 0.75em 1.25em;
   text-align: center;
 

--- a/source/stylesheets/modules/_footer.scss
+++ b/source/stylesheets/modules/_footer.scss
@@ -73,7 +73,6 @@
   @include media($medium-screen-up) {
     display: inline-block;
     float: left;
-    margin-right: 2em;
   }
 }
 
@@ -95,3 +94,6 @@
   width: 82px;
 }
 
+.github-link {
+  margin-top: -10px;
+}

--- a/source/stylesheets/modules/_global-nav.scss
+++ b/source/stylesheets/modules/_global-nav.scss
@@ -27,11 +27,7 @@
 
 .global-nav-item {
   display: inline-block;
-  margin-right: 0.5em;
-
-  &:last-child {
-    margin-right: 0;
-  }
+  margin-right: 0;
 
   a {
     color: $global-nav-link-color;
@@ -40,10 +36,6 @@
       color: $global-nav-link-hover-color;
     }
   }
-
-  @include media($medium-screen-up) {
-    margin-right: 2em;
-  }
 }
 
 a.cta-link-nav-filled {
@@ -51,3 +43,18 @@ a.cta-link-nav-filled {
   padding: 0px 15px;
 }
 
+.twitter-share-button {
+  display: none;
+
+  @include media($medium-screen-up) {
+    display: inline-block;
+    margin-right: 1em;
+    position: relative !important;
+    top: 4px;
+  }
+}
+
+.github-btn {
+  position: relative;
+  top: 14px;
+}

--- a/source/stylesheets/modules/landing/_cta.scss
+++ b/source/stylesheets/modules/landing/_cta.scss
@@ -4,7 +4,7 @@
 
   @include media($medium-screen-up) {
     padding: 0 0 6em;
-    margin-top: 0;
+    margin-top: 2em;
   }
 
   &-description {
@@ -13,11 +13,9 @@
 
   &-button-fill {
     @include button-filled($red);
-    margin: 2em 0.5em;
   }
 
   &-button-outline {
     @include button-outline($red, $red);
-    margin: 2em 0.5em;
   }
 }


### PR DESCRIPTION
- Added partials for Twitter & Github widgets, used in global-nav and footer.
- Added github and documentation links under hero on landing

![confidant_docs](https://cloud.githubusercontent.com/assets/5547897/10867166/4bc8963c-8011-11e5-8296-e81bd5999866.gif)

cc: @ryan-lane 
