### PR TITLE
Redirect to Envoy webstie 

### DIFF
--- a/src/pages/envoy*.tsx
+++ b/src/pages/envoy*.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+export default () => {
+    if (typeof window !== 'undefined') {
+        window.location.href = 'https://www.envoyproxy.io';
+    }
+    return null;
+};


### PR DESCRIPTION
Fixes #11

It will redirect any path starting with `/envoy` to Envoy's website. Since we don't have a server we can not do proper 301. 